### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Perplexity MCP Server
 
+[![smithery badge](https://smithery.ai/badge/mcp-server-perplexity)](https://smithery.ai/server/mcp-server-perplexity)
+
 MCP Server for the Perplexity API.
 
 > :warning: **Limitations:**


### PR DESCRIPTION
This PR makes a change to the README.

1. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/mcp-server-perplexity

Let me know if any tweaks have to be made!